### PR TITLE
fix(datamodel): use datamodelutils

### DIFF
--- a/authutils/auth_driver.py
+++ b/authutils/auth_driver.py
@@ -7,7 +7,7 @@ import sqlalchemy
 import userdatamodel
 from userdatamodel.user import AccessPrivilege
 
-from gdcdatamodel import models
+from datamodelutils import models
 from cdiserrors import (
     AuthError,
     InternalError,

--- a/authutils/dbgap.py
+++ b/authutils/dbgap.py
@@ -9,7 +9,7 @@ import re
 
 import xmltodict
 from cdislogging import get_logger
-from gdcdatamodel.models import Project
+from datamodelutils import models
 from xml.parsers.expat import ExpatError
 from cdiserrors import (
     InternalError,
@@ -125,7 +125,7 @@ class dbGaPXReferencer(object):
                          .format(program_name, project_code))
 
         with self.db.session_scope():
-            project = (self.db.nodes(Project)
+            project = (self.db.nodes(models.Project)
                        .props(code=project_code)
                        .path('programs')
                        .props(name=program_name)

--- a/authutils/federated_user.py
+++ b/authutils/federated_user.py
@@ -9,7 +9,7 @@ import flask_sqlalchemy_session
 import userdatamodel
 from userdatamodel.user import AccessPrivilege, HMACKeyPair, User
 
-from gdcdatamodel import models
+from datamodelutils import models
 from cdiserrors import (
     AuthError,
     InternalError,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.2#egg=cdis_oauth2cl
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.2#egg=cdispyutils
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.0.4#egg=cdiserrors
-git+https://git@github.com/NCI-GDC/gdcdatamodel.git@1.12.0#egg=gdcdatamodel
 git+https://git@github.com/uc-cdis/userdatamodel.git@cb7143c709a1173c84de4577d3e866318a2cc834#egg=userdatamodel
+git+https://git@github.com/uc-cdis/datamodelutils.git@0.3.0#egg=userdatamodel
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'cdislogging',
         'cdiserrors',
         'cdispyutils',
-        'gdcdatamodel',
+        'datamodelutils',
         'userdatamodel',
         'Flask',
         'Flask-SQLAlchemy-Session',


### PR DESCRIPTION
sheepdog requires all dependencies not use gdcdatamodel
because gdcdatamodel will use install gdcdictionary on load and sheepdog support loading dictionary from url.