### PR TITLE
feat(expired-error): add specific error for expiration

### DIFF
--- a/authutils/errors.py
+++ b/authutils/errors.py
@@ -11,6 +11,11 @@ class JWTError(AuthError):
     pass
 
 
+class JWTExpiredError(AuthError):
+
+    pass
+
+
 class JWTPurposeError(JWTError):
 
     pass

--- a/authutils/token/validate.py
+++ b/authutils/token/validate.py
@@ -4,7 +4,12 @@ import flask
 import jwt
 from werkzeug.local import LocalProxy
 
-from authutils.errors import JWTError, JWTAudienceError, JWTPurposeError
+from authutils.errors import (
+    JWTError,
+    JWTAudienceError,
+    JWTExpiredError,
+    JWTPurposeError,
+)
 import authutils.token.keys
 
 
@@ -98,6 +103,8 @@ def _validate_jwt(encoded_token, public_key, aud, iss):
         )
     except jwt.InvalidAudienceError as e:
         raise JWTAudienceError(e)
+    except jwt.ExpiredSignatureError as e:
+        raise JWTExpiredError(e)
     except jwt.InvalidTokenError as e:
         raise JWTError(e)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,15 @@ def encoded_jwt(claims, private_key):
 
 
 @pytest.fixture(scope='session')
+def encoded_jwt_expired(claims, private_key):
+    claims_expired = claims.copy()
+    # Move issued and expiration times into the past.
+    claims_expired['iat'] -= 100000
+    claims_expired['exp'] -= 100000
+    return jwt.encode(claims_expired, key=private_key, algorithm='RS256')
+
+
+@pytest.fixture(scope='session')
 def auth_header(encoded_jwt):
     """
     Return an authorization header containing the example JWT.

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -9,6 +9,7 @@ import requests
 from authutils.errors import (
     JWTError,
     JWTAudienceError,
+    JWTExpiredError,
 )
 from authutils.token.keys import (
     get_public_key_for_kid,
@@ -32,6 +33,12 @@ def test_valid_signature(
     )
     assert decoded_token
     assert decoded_token == claims
+
+
+def test_expired_token_rejected(
+        encoded_jwt_expired, public_key, default_audiences, iss):
+    with pytest.raises(JWTExpiredError):
+        _validate_jwt(encoded_jwt_expired, public_key, default_audiences, iss)
 
 
 def test_invalid_signature_rejected(


### PR DESCRIPTION
- Adds a `JWTExpiredError` to be more specific about when the token failed to validate because it's expired.
- Adds fixture and unit test for expired token to check the error is raised.