### PR TITLE
feat(multi-tenant): update token functions

### DIFF
--- a/authutils/token/keys.py
+++ b/authutils/token/keys.py
@@ -137,7 +137,7 @@ def get_public_key(iss=None, kid=None, attempt_refresh=True):
         or (kid and kid not in flask.current_app.jwt_public_keys)
     )
     if need_refresh and attempt_refresh:
-        refresh_jwt_public_keys()
+        refresh_jwt_public_keys(iss)
     if iss not in flask.current_app.jwt_public_keys:
         raise JWTError('issuer not found: {}'.format(iss))
     iss_public_keys = flask.current_app.jwt_public_keys[iss]

--- a/authutils/token/validate.py
+++ b/authutils/token/validate.py
@@ -63,7 +63,7 @@ def _validate_purpose(claims, pur):
         )
 
 
-def _validate_jwt(encoded_token, public_key, aud, iss):
+def _validate_jwt(encoded_token, public_key, aud, issuers):
     """
     Validate the encoded JWT ``encoded_token``, which must satisfy the
     audiences ``aud``.
@@ -87,6 +87,12 @@ def _validate_jwt(encoded_token, public_key, aud, iss):
     Raises:
         JWTValidationError: if any step of the validation fails
     """
+    # Typecheck arguments and convert as necessary.
+    if isinstance(aud, str):
+        aud = {aud}
+    if isinstance(issuers, str):
+        issuers = {issuers}
+
     # To satisfy PyJWT, since the token will contain an aud field, decode has
     # to be passed one of the audiences to check here (so PyJWT doesn't raise
     # an InvalidAudienceError). Per the JWT specification, if the token
@@ -113,8 +119,8 @@ def _validate_jwt(encoded_token, public_key, aud, iss):
 
     # iss
     # Check that the issuer of the token has the expected hostname.
-    if token['iss'] != iss:
-        msg = 'invalid issuer {}; expected {}'.format(token['iss'], iss)
+    if token['iss'] not in issuers:
+        msg = 'invalid issuer {}; expected: {}'.format(token['iss'], issuers)
         raise JWTError(msg)
 
     # aud
@@ -129,7 +135,7 @@ def _validate_jwt(encoded_token, public_key, aud, iss):
 
 
 def validate_jwt(
-        encoded_token, aud, purpose='access', iss=None, public_key=None):
+        encoded_token, aud, purpose='access', issuers=None, public_key=None):
     """
     Validate a JWT and return the claims.
 
@@ -141,6 +147,7 @@ def validate_jwt(
         purpose (Optional[str]):
             which purpose the token is supposed to be used for (access,
             refresh, or id)
+        issuers (Iterable[str]): list of allowed token issuers
         public_key (Optional[str]): public key to vaidate JWT with
 
     Return:
@@ -152,20 +159,22 @@ def validate_jwt(
             if auth header is missing, decoding fails, or the JWT fails to
             satisfy any expectation
     """
-    iss = (
-        iss
-        or flask.current_app.config.get('OIDC_ISSUER')
-        or flask.current_app.config['USER_API']
-    )
+    if not issuers:
+        issuers = []
+        issuers.append(
+            flask.current_app.config.get('OIDC_ISSUER')
+            or flask.current_app.config['USER_API']
+        )
     if public_key is None:
         token_headers = jwt.get_unverified_header(encoded_token)
-        public_key = authutils.token.keys.get_public_key_for_kid(
-            token_headers.get('kid'), attempt_refresh=True
+        token_iss = jwt.decode(encoded_token, verify=False).get('iss')
+        public_key = authutils.token.keys.get_public_key(
+            token_iss, token_headers.get('kid'), attempt_refresh=True
         )
     if not aud:
         raise ValueError('must provide at least one audience')
     aud = set(aud)
-    claims = _validate_jwt(encoded_token, public_key, aud, iss)
+    claims = _validate_jwt(encoded_token, public_key, aud, issuers)
     if purpose:
         _validate_purpose(claims, purpose)
     return claims

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="authutils",
-    version='0.0.1',
+    version='2.0.0',
     description="Gen3 auth utility functions.",
     license="Apache",
     packages=find_packages(),

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -11,9 +11,7 @@ from authutils.errors import (
     JWTAudienceError,
     JWTExpiredError,
 )
-from authutils.token.keys import (
-    get_public_key_for_kid,
-)
+from authutils.token.keys import get_public_key
 from authutils.token.validate import (
     _validate_jwt,
     require_auth_header,
@@ -79,8 +77,11 @@ def test_get_public_key(app, example_keys_response, mock_get):
     """
     mock_get()
     test_kid, expected_key = example_keys_response['keys'][0]
-    expected_jwt_public_keys_dict = OrderedDict(example_keys_response['keys'])
-    key = get_public_key_for_kid(test_kid)
+    iss = app.config['USER_API']
+    expected_jwt_public_keys_dict = {
+        iss: OrderedDict(example_keys_response['keys'])
+    }
+    key = get_public_key(kid=test_kid)
     requests.get.assert_called_once()
     assert key
     assert key == expected_key
@@ -94,7 +95,7 @@ def test_get_nonexistent_public_key_fails(app, mock_get):
     """
     mock_get()
     with pytest.raises(JWTError):
-        get_public_key_for_kid('nonsense')
+        get_public_key('nonsense')
 
 
 def test_validate_request_jwt(client, auth_header, mock_get):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -27,7 +27,7 @@ def test_valid_signature(
     the fence README.
     """
     decoded_token = _validate_jwt(
-        encoded_jwt, public_key, default_audiences, iss
+        encoded_jwt, public_key, default_audiences, [iss]
     )
     assert decoded_token
     assert decoded_token == claims
@@ -36,7 +36,9 @@ def test_valid_signature(
 def test_expired_token_rejected(
         encoded_jwt_expired, public_key, default_audiences, iss):
     with pytest.raises(JWTExpiredError):
-        _validate_jwt(encoded_jwt_expired, public_key, default_audiences, iss)
+        _validate_jwt(
+            encoded_jwt_expired, public_key, default_audiences, [iss]
+        )
 
 
 def test_invalid_signature_rejected(
@@ -47,7 +49,7 @@ def test_invalid_signature_rejected(
     """
     with pytest.raises(JWTError):
         _validate_jwt(
-            encoded_jwt, different_public_key, default_audiences, iss
+            encoded_jwt, different_public_key, default_audiences, [iss]
         )
 
 
@@ -57,7 +59,7 @@ def test_invalid_aud_rejected(encoded_jwt, public_key, iss):
     appear in the token, a ``JWTAudienceError`` is raised.
     """
     with pytest.raises(JWTAudienceError):
-        _validate_jwt(encoded_jwt, public_key, {'not-in-aud'}, iss)
+        _validate_jwt(encoded_jwt, public_key, {'not-in-aud'}, [iss])
 
 
 def test_invalid_iss_rejected(encoded_jwt, public_key, iss):
@@ -67,7 +69,7 @@ def test_invalid_iss_rejected(encoded_jwt, public_key, iss):
     """
     wrong_iss = iss + 'garbage'
     with pytest.raises(JWTError):
-        _validate_jwt(encoded_jwt, public_key, {'not-in-aud'}, wrong_iss)
+        _validate_jwt(encoded_jwt, public_key, {'not-in-aud'}, [wrong_iss])
 
 
 def test_get_public_key(app, example_keys_response, mock_get):
@@ -95,7 +97,7 @@ def test_get_nonexistent_public_key_fails(app, mock_get):
     """
     mock_get()
     with pytest.raises(JWTError):
-        get_public_key('nonsense')
+        get_public_key(kid='nonsense')
 
 
 def test_validate_request_jwt(client, auth_header, mock_get):


### PR DESCRIPTION
For uc-cdis/fence#75.

- `flask.current_app.jwt_public_keys` will now be a dictionary mapping issuer strings to `OrderedDict`s
- Change JWT validation to allow a list of issuers instead of a single one
- Update tests accordingly