### PR TITLE
fix(key-fixture): fix typo

### DIFF
--- a/authutils/testing/fixtures/keys.py
+++ b/authutils/testing/fixtures/keys.py
@@ -67,7 +67,7 @@ def rsa_private_key(_hazmat_rsa_private_key):
 
 
 @pytest.fixture(scope='session')
-def rsa_private_key_2(_hazmat_rsa_private_key):
+def rsa_private_key_2(_hazmat_rsa_private_key_2):
     """
     Return a (second, different) string of an RSA private key in PEM format.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-SQLAlchemy-Session==1.1
 requests==2.7.0
 python-keystoneclient==1.8.1
-PyYAML==3.11
+PyYAML==3.12
 sqlalchemy==0.9.9
 Werkzeug==0.12.2
 xmltodict==0.9.2


### PR DESCRIPTION
Fix a typo in the `rsa_private_key_2` fixture.