### PR TITLE
refactor(kid): default to most recent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ Define pytest fixtures for testing auth utils.
 """
 
 from datetime import datetime, timedelta
-import os
 import uuid
 
 import flask
@@ -78,7 +77,7 @@ def claims(default_audiences, iss):
 
 @pytest.fixture(scope='session')
 def default_kid():
-    return 'key-01'
+    return 'fence_key_2018-03-19T12:31:57Z'
 
 
 @pytest.fixture(scope='session')
@@ -94,6 +93,8 @@ def example_keys_response(default_kid, rsa_public_key, rsa_public_key_2):
     """
     return {
         'keys': [
+            [default_kid, rsa_public_key],
+            ['fence_key_2018-03-19T12:31:57Z', rsa_public_key],
             [default_kid, rsa_public_key],
             ['key-02', rsa_public_key_2]
         ]

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -96,14 +96,16 @@ def test_get_public_key(app, example_keys_response, mock_get):
     assert app.jwt_public_keys == expected_jwt_public_keys_dict
 
 
-def test_get_nonexistent_public_key_fails(app, mock_get):
+def test_get_nonexistent_public_key(app, example_keys_response, mock_get):
     """
-    Test that if there is no key found for the provided key id, a
-    JWTValidationError is raised.
+    Test that if there is no key found for the provided key id, authutils
+    defaults to the most recent key.
     """
     mock_get()
-    with pytest.raises(JWTError):
-        get_public_key(kid='nonsense')
+    key = get_public_key(kid='nonsense')
+    _, expected_key = example_keys_response['keys'][0]
+    assert key
+    assert key == expected_key
 
 
 def test_validate_request_jwt(client, auth_header, mock_get):


### PR DESCRIPTION
- Update docs in authutils about JWT keys
- Change the behavior when a key ID doesn't match existing keys; just use the most recent key in the `app.jwt_public_keys` to try to check, and log a warning