### PR TITLE
fix(jwt): catch jwt error

### DIFF
--- a/authutils/token/keys.py
+++ b/authutils/token/keys.py
@@ -158,10 +158,17 @@ def get_public_key_for_token(encoded_token, attempt_refresh=True):
     Return:
         str: public RSA key for token verification
     """
-    kid = jwt.get_unverified_header(encoded_token).get("kid")
+    try:
+        kid = jwt.get_unverified_header(encoded_token).get("kid")
+    except jwt.InvalidTokenError as e:
+        raise JWTError(e)
+
     force_issuer = flask.current_app.config.get("FORCE_ISSUER")
     if force_issuer:
         iss = flask.current_app.config["USER_API"]
     else:
-        iss = jwt.decode(encoded_token, verify=False).get("iss")
+        try:
+            iss = jwt.decode(encoded_token, verify=False).get("iss")
+        except jwt.InvalidTokenError as e:
+            raise JWTError(e)
     return get_public_key(kid, iss=iss, attempt_refresh=attempt_refresh)

--- a/authutils/token/validate.py
+++ b/authutils/token/validate.py
@@ -218,6 +218,7 @@ def validate_request(aud, purpose="access"):
         raise JWTError("could not parse authorization header")
     except KeyError:
         raise JWTError("no authorization header provided")
+
     # Pass token to ``validate_jwt``.
     return validate_jwt(encoded_token, aud, purpose)
 


### PR DESCRIPTION
fix unhandled exception. Currently if you pass `Authorization: bearer abc' it triggers 500