### PR TITLE
fix(qa): authlib 0.14.3 breaks sheepdog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Authutils release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  build-and-run:
+    name: Build and Run
+    runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, 'release')
+    steps:
+      - uses: actions/checkout@v1
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GEN3_GITHUB_TOKEN }}"
+      - name: fix remote
+        run: git remote set-url origin https://github.com/uc-cdis/pelican.git
+      - name: switch to master branch
+        run: git checkout master
+      - name: Bump release version
+        id: bump_version
+        uses: christian-draeger/increment-semantic-version@1.0.0
+        with:
+          current-version: ${{ steps.previoustag.outputs.tag }}
+          version-fragment: 'bug'
+      - name: Install Gen3 release-helper
+        run: |
+          pip install wheel
+          pip install --user --editable git+https://github.com/uc-cdis/release-helper.git@master#egg=gen3git
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} tag ${{ steps.bump_version.outputs.next-version }}
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} release
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} gen --markdown
+          cat release_notes.md
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.bump_version.outputs.next-version }}
+          artifacts: "release.tar.gz,foo/*.txt"
+          bodyFile: "release_notes.md"
+          token: ${{ secrets.GEN3_GITHUB_TOKEN }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,7 +27,7 @@ description = "The ultimate Python library in building OAuth and OpenID Connect 
 name = "authlib"
 optional = false
 python-versions = "*"
-version = "0.14.3"
+version = "0.14.2"
 
 [package.dependencies]
 cryptography = "*"
@@ -565,11 +565,11 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "dev"
-description = "Measures number of Terminal column cells of wide-character codes"
+description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.1.9"
+version = "0.2.2"
 
 [[package]]
 category = "main"
@@ -609,7 +609,7 @@ fastapi = ["fastapi"]
 flask = ["Flask"]
 
 [metadata]
-content-hash = "eca68711f4c2475f63aa987f54d3508132e4abae8bcf86996517ac25508d9006"
+content-hash = "28bc88de5ab9cf494df5de70b327f576b791dac01f565bbed838d4134e628f73"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -622,8 +622,8 @@ attrs = [
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 authlib = [
-    {file = "Authlib-0.14.3-py2.py3-none-any.whl", hash = "sha256:270e778201590af8873cf7d5e8e8ca5b625a16f7afba6a4280b6fb4efdd791bf"},
-    {file = "Authlib-0.14.3.tar.gz", hash = "sha256:cc52908e9e996f3de2ac2f61bf1ee6c6f1c5ce8e67c89ff2ca473008fffc92f6"},
+    {file = "Authlib-0.14.2-py2.py3-none-any.whl", hash = "sha256:f07f373fd08994a1638f8f09ffc09d4f13c5eab4d070c5c9307745fb178a65ec"},
+    {file = "Authlib-0.14.2.tar.gz", hash = "sha256:94958661bd9e1c236a43719f00c5e6da2b7a773bd7350961be9fd9f3298da658"},
 ]
 cached-property = [
     {file = "cached-property-1.5.1.tar.gz", hash = "sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504"},
@@ -833,6 +833,11 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mock = [
@@ -923,8 +928,8 @@ urllib3 = [
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},
-    {file = "wcwidth-0.1.9.tar.gz", hash = "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"},
+    {file = "wcwidth-0.2.2-py2.py3-none-any.whl", hash = "sha256:b651b6b081476420e4e9ae61239ac4c1b49d0c5ace42b2e81dc2ff49ed50c566"},
+    {file = "wcwidth-0.2.2.tar.gz", hash = "sha256:3de2e41158cb650b91f9654cbf9a3e053cee0719c9df4ddc11e4b568669e9829"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ cached-property = "~=1.4"
 cdiserrors = "~=1.0"
 xmltodict = "~=0.9"
 
-authlib = "~=0.11"
+authlib = "<0.14.3"
 httpx = "^0.12.1"
 pyjwt = {version = "~=1.5", extras = ["crypto"]}
 


### PR DESCRIPTION
This version of authlib breaks our Sheepdog service.


### Bug Fixes
This should address the following error:
```
sheepdog-service     |     from authlib.client import OAuthClient
sheepdog-service     |   File "/usr/local/lib/python3.6/site-packages/authlib/client/__init__.py", line 9, in <module>
sheepdog-service     |     from .oauth_client import OAuthClient, OAUTH_CLIENT_PARAMS
sheepdog-service     |   File "/usr/local/lib/python3.6/site-packages/authlib/client/oauth_client.py", line 1, in <module>
sheepdog-service     |     from authlib.integrations._client import RemoteApp as OAuthClient
sheepdog-service     | ModuleNotFoundError: No module named 'authlib.integrations._client'
sheepdog-service     | unable to load 
```
