### PR TITLE
(PXP-6339): Fetch and cache public keys for JWT validation

### DIFF
--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -151,7 +151,7 @@ def validate_jwt(encoded_token, public_key, aud, scope, issuers, options={}):
     if scope:
         token_scopes = token.get("scope", [])
         if isinstance(token_scopes, str):
-            token_scopes = [token_scopes]
+            token_scopes = token_scopes.split()
         if not isinstance(token_scopes, list):
             raise JWTError(
                 "invalid format in scope claim: {}; expected string or list".format(

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -11,11 +11,12 @@ from ..errors import (
 
 
 def get_keys_url(issuer):
-    openid_cfg_path = "/".join([issuer.strip("/"), ".well-known", "openid-configuration"])
+    # Prefer OIDC discovery doc, but fall back on Fence-specific /jwt/keys for backwards compatibility
+    openid_cfg_path = "/".join(
+        [issuer.strip("/"), ".well-known", "openid-configuration"]
+    )
     jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
-    if jwks_uri:
-        return jwks_uri
-    return "/".join([issuer.strip("/"), "jwt", "keys"])
+    return jwks_uri if jwks_uri else "/".join([issuer.strip("/"), "jwt", "keys"])
 
 
 def get_kid(encoded_token):

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -15,8 +15,11 @@ def get_keys_url(issuer):
     openid_cfg_path = "/".join(
         [issuer.strip("/"), ".well-known", "openid-configuration"]
     )
-    jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
-    return jwks_uri if jwks_uri else "/".join([issuer.strip("/"), "jwt", "keys"])
+    try:
+        jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
+        return jwks_uri
+    except:
+        return "/".join([issuer.strip("/"), "jwt", "keys"])
 
 
 def get_kid(encoded_token):

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -1,3 +1,4 @@
+import httpx
 import jwt
 
 from ..errors import (
@@ -10,6 +11,10 @@ from ..errors import (
 
 
 def get_keys_url(issuer):
+    openid_cfg_path = "/".join([issuer.strip("/"), ".well-known", "openid-configuration"])
+    jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
+    if jwks_uri:
+        return jwks_uri
     return "/".join([issuer.strip("/"), "jwt", "keys"])
 
 

--- a/src/authutils/token/keys.py
+++ b/src/authutils/token/keys.py
@@ -98,7 +98,14 @@ def refresh_jwt_public_keys(user_api=None, logger=None):
         raise ValueError("no URL(s) provided for user API")
 
     path = get_keys_url(user_api)
-    jwt_public_keys = httpx.get(path).json()["keys"]
+    try:
+        jwt_public_keys = httpx.get(path).json()["keys"]
+    except:
+        raise JWTError(
+            "Attempted to refresh public keys for {},"
+            "but could not get keys from path {}.".format(user_api, path)
+        )
+
     logger.info("Refreshing public key cache for issuer {}...".format(user_api))
     logger.debug(
         "Received public keys:\n{}".format(json.dumps(str(jwt_public_keys), indent=4))

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -148,7 +148,9 @@ def test_get_public_key(app, example_keys_response, mock_get):
     iss = app.config["USER_API"]
     expected_jwt_public_keys_dict = {iss: OrderedDict(example_keys_response["keys"])}
     key = get_public_key(kid=test_kid)
-    httpx.get.assert_called_once()
+    # httpx.get should be called twice: once attempting to get the jwks_uri from
+    # .well-known/openid-configuration, another to actually hit the jwks_uri
+    assert httpx.get.call_count == 2
     assert key
     assert key == expected_key
     assert app.jwt_public_keys == expected_jwt_public_keys_dict


### PR DESCRIPTION
Jira Ticket: [PXP-6339](https://ctds-planx.atlassian.net/browse/PXP-6339)

### New Features
- Facilitate validation of JWTs from non-Gen3 issuers by adding ability to fetch and cache a JWK set from a non-Gen3 server. Authutils will first look for a jwks_uri at .well-known/openid-configuration and fall back to the legacy Gen3 /jwt/keys endpoint. Keys are serialized to PEM and stored (as before) in flask.current_app.jwt_public_keys. 

### Breaking Changes


### Bug Fixes


### Improvements
- Account for JWTs in which the scope claim is a space-delimited string (use split instead of just putting scope value in list). We expect RAS visas/all GA4GH embedded tokens to have scope claims with this format. 

### Dependency updates


### Deployment changes

