### PR TITLE
Fix parsing of PEM and RSA keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black

--- a/src/authutils/token/fastapi.py
+++ b/src/authutils/token/fastapi.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette.status import HTTP_403_FORBIDDEN
 
 from . import core
+from .keys import get_pem_key
 from ..errors import JWTError, AuthError
 
 bearer = HTTPBearer()
@@ -76,7 +77,9 @@ def access_token(
                 async with httpx.AsyncClient() as client:
                     resp = await client.get(core.get_keys_url(issuer))
                     resp.raise_for_status()
-                    pub_keys.set_result(OrderedDict(resp.json()["keys"]))
+                    pub_keys.set_result(
+                        OrderedDict(get_pem_key(key) for key in resp.json()["keys"])
+                    )
             except Exception as e:
                 _jwt_public_keys.pop(issuer)
                 pub_keys.set_exception(


### PR DESCRIPTION
Fix a bug introduced in [6.0.2](https://github.com/uc-cdis/authutils/releases/tag/6.0.2) by https://github.com/uc-cdis/authutils/pull/52 when using `authutils.token.fastapi.access_token`:
```
Traceback (most recent call last):
  File "/env/lib/python3.9/site-packages/authutils/token/fastapi.py", line 90, in getter
    pub_keys = await pub_keys
fastapi.exceptions.HTTPException
```
This is caused by calling the `OrderedDict` constructor with a list of dicts instead of a list of tuples.

Fence's `/.well-known/jwks` endpoint returns:
```
{
  keys: [
    {
      kid: "<kid>",
      kty: "RSA",
      n: "<key>",
      [...]
    }
  ]
}
```

while the `/jwt/keys` endpoint returns the keys in PEM format:
```
{
  keys: [
    [
      "<kid>",
      "-----BEGIN PUBLIC KEY----- <key> -----END PUBLIC KEY----- ",
    ]
  ]
}
```

Since version 6.0.2, `get_keys_url` can return the URL to either endpoint, and `access_token` was not updated to work with the non-PEM format.

### Bug Fixes
- Fix `authutils.token.fastapi.access_token` to accept both PEM and RSA key formats
