### PR TITLE
Handle `FORCE_ISSUER` in `get_keys_url()`

### DIFF
--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -10,7 +10,7 @@ from ..errors import (
 )
 
 
-def get_keys_url(issuer, force_issuer=False):
+def get_keys_url(issuer, force_issuer=None):
     # Prefer OIDC discovery doc, but fall back on Fence-specific /jwt/keys for backwards compatibility
     openid_cfg_path = "/".join(
         [issuer.strip("/"), ".well-known", "openid-configuration"]

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -10,11 +10,15 @@ from ..errors import (
 )
 
 
-def get_keys_url(issuer):
+def get_keys_url(issuer, force_issuer=False):
     # Prefer OIDC discovery doc, but fall back on Fence-specific /jwt/keys for backwards compatibility
     openid_cfg_path = "/".join(
         [issuer.strip("/"), ".well-known", "openid-configuration"]
     )
+    
+    if force_issuer:
+        return "/".join([issuer.strip("/"), "jwt", "keys"])
+    
     try:
         jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
         return jwks_uri

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -11,19 +11,21 @@ from ..errors import (
 
 
 def get_keys_url(issuer, force_issuer=None):
-    # Prefer OIDC discovery doc, but fall back on Fence-specific /jwt/keys for backwards compatibility
+    """
+    Prefer OIDC discovery doc, but fall back on Fence-specific /jwt/keys for backwards compatibility (or if `force_issuer` is True)
+    """
+    jwt_keys_url = "/".join([issuer.strip("/"), "jwt", "keys"])
+    if force_issuer:
+        return jwt_keys_url
+
     openid_cfg_path = "/".join(
         [issuer.strip("/"), ".well-known", "openid-configuration"]
     )
-
-    if force_issuer:
-        return "/".join([issuer.strip("/"), "jwt", "keys"])
-
     try:
         jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
         return jwks_uri
     except:
-        return "/".join([issuer.strip("/"), "jwt", "keys"])
+        return jwt_keys_url
 
 
 def get_kid(encoded_token):

--- a/src/authutils/token/core.py
+++ b/src/authutils/token/core.py
@@ -15,10 +15,10 @@ def get_keys_url(issuer, force_issuer=None):
     openid_cfg_path = "/".join(
         [issuer.strip("/"), ".well-known", "openid-configuration"]
     )
-    
+
     if force_issuer:
         return "/".join([issuer.strip("/"), "jwt", "keys"])
-    
+
     try:
         jwks_uri = httpx.get(openid_cfg_path).json().get("jwks_uri", "")
         return jwks_uri

--- a/src/authutils/token/keys.py
+++ b/src/authutils/token/keys.py
@@ -153,7 +153,12 @@ def refresh_jwt_public_keys(user_api=None, pkey_cache=None, logger=None):
     if not user_api:
         raise ValueError("no URL(s) provided for user API")
 
-    path = get_keys_url(user_api)
+    force_issuer = (
+        flask.current_app.config.get("FORCE_ISSUER")
+        if flask.has_app_context()
+        else None
+    )
+    path = get_keys_url(user_api, force_issuer)
     try:
         jwt_public_keys = httpx.get(path).json()["keys"]
     except:


### PR DESCRIPTION
When using the more recent versions of authutils the import statement `from authutils.user import current_user` will fail for docker compose. 

Even if the USER_API and FORCE_ISSUER env variable are set, and [this](https://github.com/uc-cdis/authutils/blob/4b43a250f448815f1ea0e7fa22fa0b02c9a2cb1d/src/authutils/token/core.py#L13) function receive as a issuer parameter `http://fence-service/` the `openid-configuration` [endpoint](https://github.com/uc-cdis/authutils/blob/4b43a250f448815f1ea0e7fa22fa0b02c9a2cb1d/src/authutils/token/core.py#L16) will return `https://localhost/user/.well-known/jwks` as a `jwks_uri` which will override the FORCE_ISSUER settings.

This PR is meant to fix this bug and allow the use of newer version with the docker compose setup

(tested with 6.1.0 and newer, it was working with 4.0.0. Haven't tested with 5). 

### Improvements
- Handle `FORCE_ISSUER` in `get_keys_url()`